### PR TITLE
Mario/89 address creation metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ How it's rated?
 
 ### Address creation
 
-The older the address is, the more trustable it might be.
+The older the address is, the more trustable it might be. The best value (older address) between the validator stash address and its parent identity address will be used for rating this metric.
 
 How it's rated?
 

--- a/pages/metrics.vue
+++ b/pages/metrics.vue
@@ -66,7 +66,7 @@ export default {
           id: 'address',
           title: 'Address creation date',
           description:
-            'The older the address is, the more trustable it might be.',
+            'The older the address is, the more trustable it might be. The best value (older address) between the validator stash address and its parent identity address will be used for rating this metric.',
           rating: [
             {
               rating: 0,

--- a/pages/validator/_id/index.vue
+++ b/pages/validator/_id/index.vue
@@ -76,7 +76,10 @@
               />
             </div>
             <div class="col-md-6 mb-5">
-              <Address :account-id="validator.stashAddress" />
+              <Address
+                :account-id="validator.stashAddress"
+                :identity="validator.identity"
+              />
             </div>
           </div>
           <div class="row">

--- a/store/ranking.js
+++ b/store/ranking.js
@@ -158,7 +158,7 @@ export const actions = {
         })
       )
     )
-    api.disconnect()
+    // api.disconnect()
     const dataCollectionEndTime = new Date().getTime()
     const dataCollectionTime = dataCollectionEndTime - startTime
     // eslint-disable-next-line


### PR DESCRIPTION
Closes #89 

Improve address creation metric:

- Use the best value (older address) between the validator stash address and its parent identity address for rating.
- Update metric definition in /metrics page and README
- Add loading text
- Show info about both addresses in metric description:

![image](https://user-images.githubusercontent.com/9256178/100997220-5091e700-355a-11eb-8c8d-88e3be286771.png)


