### PR TITLE
Add history size info and platform under development alert

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,9 +2,31 @@
   <div class="page container pt-3">
     <div>
       <b-alert show dismissible variant="info" class="text-center py-3 glitch">
-        The {{ config.title }} for {{ capitalize(config.name) }} aims to provide
-        quantitative and qualitative data about validators performance and help
-        nominators to choose their best nomination set
+        <p>
+          The {{ config.title }} for {{ capitalize(config.name) }} aims to
+          provide quantitative and qualitative data about validators performance
+          and help nominators to choose their best nomination set.
+        </p>
+        <p>
+          In order to fetch on-chain data in a reasonable amount of time the
+          size of the
+          <strong
+            >history is limited to
+            {{ config.historySize / config.erasPerDay }} days</strong
+          >
+        </p>
+      </b-alert>
+      <b-alert
+        show
+        dismissible
+        variant="warning"
+        class="text-center py-3 glitch"
+      >
+        <p>
+          This platform is currently under development and the metrics are
+          subject to change. Please do your own research before nominating your
+          validator set.
+        </p>
       </b-alert>
       <Ranking />
     </div>


### PR DESCRIPTION
Closes #88 

- Add text about history size is limited
- Add warning alert about platform is under development and metrics are subject to change

![image](https://user-images.githubusercontent.com/9256178/101007434-b897fb80-3561-11eb-9c86-3a3647d02e9a.png)
