### PR TITLE
Replace 1 cluster member per set limitation and include a warning in nominate page

### DIFF
--- a/components/Ranking.vue
+++ b/components/Ranking.vue
@@ -306,10 +306,10 @@ export default {
         { text: 'No identity', value: 'noIdentity' },
         { text: 'No verified identity', value: 'noVerifiedIdentity' },
         { text: 'No auto-payout', value: 'noAutoPayout' },
-        {
-          text: 'Cluster members',
-          value: 'partOfCluster',
-        },
+        // {
+        //   text: 'Cluster members',
+        //   value: 'partOfCluster',
+        // },
         {
           text: 'Below average era points',
           value: 'belowAverageEraPoints',
@@ -368,9 +368,9 @@ export default {
             ({ governanceRating }) => governanceRating !== 0
           )
         : filteredRanking
-      filteredRanking = this.exclude.includes('partOfCluster')
-        ? filteredRanking.filter(({ partOfCluster }) => !partOfCluster)
-        : filteredRanking
+      // filteredRanking = this.exclude.includes('partOfCluster')
+      //   ? filteredRanking.filter(({ partOfCluster }) => !partOfCluster)
+      //   : filteredRanking
       filteredRanking = this.exclude.includes('belowAverageEraPoints')
         ? filteredRanking.filter(({ eraPointsRating }) => eraPointsRating === 2)
         : filteredRanking

--- a/components/Ranking.vue
+++ b/components/Ranking.vue
@@ -306,10 +306,6 @@ export default {
         { text: 'No identity', value: 'noIdentity' },
         { text: 'No verified identity', value: 'noVerifiedIdentity' },
         { text: 'No auto-payout', value: 'noAutoPayout' },
-        // {
-        //   text: 'Cluster members',
-        //   value: 'partOfCluster',
-        // },
         {
           text: 'Below average era points',
           value: 'belowAverageEraPoints',
@@ -368,9 +364,6 @@ export default {
             ({ governanceRating }) => governanceRating !== 0
           )
         : filteredRanking
-      // filteredRanking = this.exclude.includes('partOfCluster')
-      //   ? filteredRanking.filter(({ partOfCluster }) => !partOfCluster)
-      //   : filteredRanking
       filteredRanking = this.exclude.includes('belowAverageEraPoints')
         ? filteredRanking.filter(({ eraPointsRating }) => eraPointsRating === 2)
         : filteredRanking

--- a/pages/nominate.vue
+++ b/pages/nominate.vue
@@ -168,6 +168,10 @@
           <h4>Transaction hash {{ extrinsicHash }}</h4>
           <p>Transaction status: {{ extrinsicStatus }}</p>
         </b-alert>
+        <b-alert variant="warning" v-if="clusterAlert" show dismissible>
+          You have at least more than one member of the same cluster in your
+          set. This can increase the risk of being slashed.
+        </b-alert>
         <b-button
           type="submit"
           variant="outline-primary2"
@@ -227,6 +231,7 @@ export default {
       noAccountsFound: true,
       addressRole: null,
       onGoingElection: false,
+      clusterAlert: false,
     }
   },
   head() {
@@ -248,9 +253,20 @@ export default {
       return this.$store.state.ranking.loading
     },
     list() {
-      return this.$store.state.ranking.list.filter(({ stashAddress }) =>
+      const list = this.$store.state.ranking.list.filter(({ stashAddress }) =>
         this.selectedAddresses.includes(stashAddress)
       )
+      const vm = this
+      list.forEach((validator) => {
+        const includedClusterMembers = list.filter(
+          ({ clusterName }) => clusterName === validator.clusterName
+        )
+        console.log(includedClusterMembers.length)
+        if (includedClusterMembers.length > 1) {
+          vm.clusterAlert = true
+        }
+      })
+      return list
     },
     selectedAddresses() {
       return this.$store.state.ranking.selectedAddresses

--- a/store/ranking.js
+++ b/store/ranking.js
@@ -42,28 +42,29 @@ export const mutations = {
       selectedAddresses.splice(state.selectedAddresses.indexOf(accountId), 1)
     } else if (selectedAddresses.length < 16) {
       // check if a member of the same cluster is already in the set
-      const validator = state.list.find(
-        ({ stashAddress }) => accountId === stashAddress
-      )
-      const clusterMemberAlreadyIncluded = state.list
-        .filter(({ stashAddress }) =>
-          state.selectedAddresses.includes(stashAddress)
-        )
-        .some(
-          ({ clusterName, partOfCluster }) =>
-            partOfCluster && clusterName === validator.clusterName
-        )
-      if (clusterMemberAlreadyIncluded) {
-        const bootStrapToaster = new BToast()
-        bootStrapToaster.$bvToast.toast('Cluster member already included', {
-          title: 'Selecting more than one member of a cluster is not allowed',
-          variant: 'danger',
-          autoHideDelay: 5000,
-          appendToast: false,
-        })
-      } else {
-        selectedAddresses.push(accountId)
-      }
+      // const validator = state.list.find(
+      //   ({ stashAddress }) => accountId === stashAddress
+      // )
+      // const clusterMemberAlreadyIncluded = state.list
+      //   .filter(({ stashAddress }) =>
+      //     state.selectedAddresses.includes(stashAddress)
+      //   )
+      //   .some(
+      //     ({ clusterName, partOfCluster }) =>
+      //       partOfCluster && clusterName === validator.clusterName
+      //   )
+      // if (clusterMemberAlreadyIncluded) {
+      //   const bootStrapToaster = new BToast()
+      //   bootStrapToaster.$bvToast.toast('Cluster member already included', {
+      //     title: 'Selecting more than one member of a cluster is not allowed',
+      //     variant: 'danger',
+      //     autoHideDelay: 5000,
+      //     appendToast: false,
+      //   })
+      // } else {
+      //   selectedAddresses.push(accountId)
+      // }
+      selectedAddresses.push(accountId)
     } else {
       const bootStrapToaster = new BToast()
       bootStrapToaster.$bvToast.toast(

--- a/store/ranking.js
+++ b/store/ranking.js
@@ -42,28 +42,29 @@ export const mutations = {
       selectedAddresses.splice(state.selectedAddresses.indexOf(accountId), 1)
     } else if (selectedAddresses.length < 16) {
       // check if a member of the same cluster is already in the set
-      // const validator = state.list.find(
-      //   ({ stashAddress }) => accountId === stashAddress
-      // )
-      // const clusterMemberAlreadyIncluded = state.list
-      //   .filter(({ stashAddress }) =>
-      //     state.selectedAddresses.includes(stashAddress)
-      //   )
-      //   .some(
-      //     ({ clusterName, partOfCluster }) =>
-      //       partOfCluster && clusterName === validator.clusterName
-      //   )
-      // if (clusterMemberAlreadyIncluded) {
-      //   const bootStrapToaster = new BToast()
-      //   bootStrapToaster.$bvToast.toast('Cluster member already included', {
-      //     title: 'Selecting more than one member of a cluster is not allowed',
-      //     variant: 'danger',
-      //     autoHideDelay: 5000,
-      //     appendToast: false,
-      //   })
-      // } else {
-      //   selectedAddresses.push(accountId)
-      // }
+      const validator = state.list.find(
+        ({ stashAddress }) => accountId === stashAddress
+      )
+      const clusterMemberAlreadyIncluded = state.list
+        .filter(({ stashAddress }) =>
+          state.selectedAddresses.includes(stashAddress)
+        )
+        .some(
+          ({ clusterName, partOfCluster }) =>
+            partOfCluster && clusterName === validator.clusterName
+        )
+      if (clusterMemberAlreadyIncluded) {
+        const bootStrapToaster = new BToast()
+        bootStrapToaster.$bvToast.toast(
+          'Selecting more than one member of a cluster is not recommended',
+          {
+            title: 'Cluster already included!',
+            variant: 'warning',
+            autoHideDelay: 5000,
+            appendToast: false,
+          }
+        )
+      }
       selectedAddresses.push(accountId)
     } else {
       const bootStrapToaster = new BToast()


### PR DESCRIPTION
Closes #87 

- Removed Cluster members exclude filter
- Removed 1 cluster member per set limitation
- Included warning in nominate page if the validator set includes more than 1 members of a cluster